### PR TITLE
Fix slicer build dependencies and documentation

### DIFF
--- a/code-slicer/README.md
+++ b/code-slicer/README.md
@@ -12,7 +12,7 @@ This slicer is based on [Joern Fuzzy Code parser](https://github.com/octopus-pla
 wget https://services.gradle.org/distributions/gradle-2.0-bin.zip
 sudo mkdir /opt/gradle
 sudo unzip gradle-2.0-bin.zip -d /opt/gradle
-echo 'export PATH="$PATH:/opt/gradle/gradle-2.0/bin"' > ~/.bashrc
+echo 'export PATH="$PATH:/opt/gradle/gradle-2.0/bin"' >> ~/.bashrc
 source ~/.bashrc
 ```
 3. Graphviz (`sudo apt install graphviz-dev`)

--- a/code-slicer/README.md
+++ b/code-slicer/README.md
@@ -7,9 +7,16 @@ This slicer is based on [Joern Fuzzy Code parser](https://github.com/octopus-pla
 
 ## Depndencies
 
-1. Gradle (`sudo apt-get install gradle`)
-2. Graphviz (`sudo apt install graphviz-dev`)
-3. Python >= 3.5
+1. Gradle 2.0, which further requires Java 8 (`sudo apt-get install openjdk-8-jdk`)
+```
+wget https://services.gradle.org/distributions/gradle-2.0-bin.zip
+sudo mkdir /opt/gradle
+sudo unzip gradle-2.0-bin.zip -d /opt/gradle
+echo 'export PATH="$PATH:/opt/gradle/gradle-2.0/bin"' > ~/.bashrc
+source ~/.bashrc
+```
+3. Graphviz (`sudo apt install graphviz-dev`)
+4. Python >= 3.5 with graphviz library (`pip install graphviz`)
 
 ## Installation
 1. Enter into the source code

--- a/code-slicer/README.md
+++ b/code-slicer/README.md
@@ -21,7 +21,7 @@ source ~/.bashrc
 ## Installation
 1. Enter into the source code
     ```
-    cd C-Code-Slicer
+    cd code-slicer
    ```
 2. Build **Joern**
     ```

--- a/code-slicer/joern/build.gradle
+++ b/code-slicer/joern/build.gradle
@@ -19,6 +19,7 @@ allprojects {
     apply plugin: 'java'
     repositories {
         // mavenCentral()
+        // The above line tries to access repo1.maven.org/maven2 through http while https is required.
         maven {
             url "https://repo1.maven.org/maven2"
         }

--- a/code-slicer/joern/build.gradle
+++ b/code-slicer/joern/build.gradle
@@ -17,7 +17,12 @@ if ( gradleVersionMajor < reguiredGradleVersionMajor ||
 
 allprojects {
     apply plugin: 'java'
-    repositories { mavenCentral() }
+    repositories {
+        // mavenCentral()
+        maven {
+            url "https://repo1.maven.org/maven2"
+        }
+    }
 }
 
 // Python utilities

--- a/code-slicer/parse_joern_output.py
+++ b/code-slicer/parse_joern_output.py
@@ -86,9 +86,9 @@ def create_visual_graph(code, adjacency_list, file_name='test_graph', verbose=Fa
         graph.node(str(ln), str(ln) + '\t' + code[ln], shape='box')
         control_dependency, data_dependency = adjacency_list[ln]
         for anode in control_dependency:
-            graph.edge(str(ln), str(anode), color='red', label='control')
+            graph.edge(str(ln), str(anode), color='red')
         for anode in data_dependency:
-            graph.edge(str(ln), str(anode), color='blue', label='data')
+            graph.edge(str(ln), str(anode), color='blue')
     graph.render(file_name, view=verbose)
     print(graph)
 

--- a/code-slicer/parse_joern_output.py
+++ b/code-slicer/parse_joern_output.py
@@ -86,9 +86,9 @@ def create_visual_graph(code, adjacency_list, file_name='test_graph', verbose=Fa
         graph.node(str(ln), str(ln) + '\t' + code[ln], shape='box')
         control_dependency, data_dependency = adjacency_list[ln]
         for anode in control_dependency:
-            graph.edge(str(ln), str(anode), color='red')
+            graph.edge(str(ln), str(anode), color='red', label='control')
         for anode in data_dependency:
-            graph.edge(str(ln), str(anode), color='blue')
+            graph.edge(str(ln), str(anode), color='blue', label='data')
     graph.render(file_name, view=verbose)
     print(graph)
 

--- a/code-slicer/test/test1.c
+++ b/code-slicer/test/test1.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    char *x = argv[1];
+    if (atoi(x) > 3) {
+        printf("Hello, %s!\n", x);
+    }
+    else {
+        printf("Salutations, %s!\n", x);
+    }
+    printf("Goodbye, %s!\n", x);
+}


### PR DESCRIPTION
Thanks for open sourcing this project. I've been using it and wanted to contribute back my fixes. These changes were required to make the readme instructions for `code-slicer` work on a modern system.

Version information:
```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.1 LTS
Release:        20.04
Codename:       focal
```